### PR TITLE
Despacer

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -13,6 +13,13 @@ LOG_FILE=/flywheel/v0/output/$GEAR.log
 (
   echo -e "$CONTAINER  Initiated"
   set -e
+  ###############################################################################
+  # Utilities
+
+  # Remove the spaces in directory and filenames recursively
+  despacer () {
+    find "$1" -depth -name "* *" -execdir rename 's/ /_/g' "{}" \;
+  }
 
   ###############################################################################
   # Configure Freesurfer and MCR ENV
@@ -53,6 +60,9 @@ LOG_FILE=/flywheel/v0/output/$GEAR.log
   ###############################################################################
   # Check for anatomical NIfTI or DICOM archive
 
+  # Despace filenames
+  despacer "${ANAT_DIR}"
+
   # NIfTI input file
   ANATOMICAL=$(find ${ANAT_DIR}/* -name "*.nii*")
 
@@ -67,7 +77,8 @@ LOG_FILE=/flywheel/v0/output/$GEAR.log
       mkdir ${DICOM_DIR}
       unzip -q "${ANATOMICAL}" -d ${DICOM_DIR}
 
-      # Get the path to the first dicom file for input to recon-all
+      # Get the 'despaced' path to the first dicom file for input to recon-all
+      despacer "${DICOM_DIR}"
       ANATOMICAL=$(find ${DICOM_DIR}/* -not -path '*/\.*' -type f | head -1)
     fi
 
@@ -89,7 +100,7 @@ LOG_FILE=/flywheel/v0/output/$GEAR.log
     CONFIG_FILE=${MANIFEST_FILE}
   fi
 
-  SUBJECT_ID=`${FLYWHEEL_BASE}/parse_config.py --json_file=${CONFIG_FILE} -i`
+  SUBJECT_ID=$(echo `${FLYWHEEL_BASE}/parse_config.py --json_file=${CONFIG_FILE} -i` | sed 's/ /_/g')
   RECON_ALL_OPTS=`${FLYWHEEL_BASE}/parse_config.py --json_file=${CONFIG_FILE} -o`
   CONVERT_SURFACES=`${FLYWHEEL_BASE}/parse_config.py --json_file=${CONFIG_FILE} -s`
   CONVERT_VOLUMES=`${FLYWHEEL_BASE}/parse_config.py --json_file=${CONFIG_FILE} -n`

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   "source": "https://github.com/scitran-apps/freesurfer-recon-all",
   "license": "GPL-2.0",
   "flywheel": "0",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "inputs": {
     "anatomical": {
       "description": "Anatomical NIfTI file or DICOM archive.",
@@ -84,6 +84,6 @@
     }
   },
   "custom": {
-    "docker-image": "scitran/freesurfer-recon-all:v0.1.0"
+    "docker-image": "scitran/freesurfer-recon-all:v0.1.1"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "freesurfer-recon-all",
   "label": "FreeSurfer (v6.0.0): Recon-All",
-  "description": " This gear takes an anatomical NIfTI file and performs all of the FreeSurfer cortical reconstruction process. Outputs are provided in a zip file and include the entire output directory tree from Recon-All. Configuration options exist for setting the subejct ID and for converting outputs to NIfTI, OBJ, and CSV. FreeSurfer is a software package for the analysis and visualization of structural and functional neuroimaging data from cross-sectional or longitudinal studies. It is developed by the Laboratory for Computational Neuroimaging at the Athinoula A. Martinos Center for Biomedical Imaging. Please see https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense for license information.",
+  "description": " This gear takes an anatomical NIfTI file and performs all of the FreeSurfer cortical reconstruction process. Outputs are provided in a zip file and include the entire output directory tree from Recon-All. Configuration options exist for setting the subject ID and for converting outputs to NIfTI, OBJ, and CSV. FreeSurfer is a software package for the analysis and visualization of structural and functional neuroimaging data from cross-sectional or longitudinal studies. It is developed by the Laboratory for Computational Neuroimaging at the Athinoula A. Martinos Center for Biomedical Imaging. Please see https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense for license information.",
   "maintainer": "Michael Perry <lmperry@stanford.edu>",
   "author": "FREESURFER <freesurfer@nmr.mgh.harvard.edu>",
   "url": "https://surfer.nmr.mgh.harvard.edu",
@@ -23,7 +23,7 @@
   },
   "config": {
     "subject_id": {
-      "description": "Desired subject ID (Default='s000'). This will be used to name the resulting freesurfer output directory.",
+      "description": "Desired subject ID (Default='s000'). Any spaces in the subject_id will be replaced with underscores and will be used to name the resulting FreeSurfer output directory.",
       "default": "s000",
       "type": "string"
     },


### PR DESCRIPTION
removes spaces in input filenames and subject ID - which was causing recon-all to crash and burn. 

Closes #8 